### PR TITLE
Fixed function call in DoctrineCollection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ use DeepCopy\Matcher\PropertyTypeMatcher;
 use Doctrine\Common\Collections\Collection;
 
 $copier = new DeepCopy();
-$copier->addTypeFilter(
+$copier->addFilter(
     new DoctrineCollectionFilter(),
     new PropertyTypeMatcher(Collection::class)
 );


### PR DESCRIPTION
The DoctrineCollectionFilter example was using the `addTypeFilter` method, but it should have been `addFilter`